### PR TITLE
Fix1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,10 +4,10 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   has_one_attached :image
-  has_many :memos
-  has_many :tweets
-  has_many :likes
-  has_many :comments
+  has_many :memos ,dependent: :destroy
+  has_many :tweets, dependent: :destroy
+  has_many :likes, dependent: :destroy
+  has_many :comments, dependent: :destroy
   has_many :following_relationships, foreign_key: "follower_id", class_name: "Relationship", dependent: :destroy
   has_many :following, through: :following_relationships
   has_many :follower_relationships, foreign_key: "following_id", class_name: "Relationship", dependent: :destroy

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,32 +1,35 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-dark bg-dark">
-    <%= link_to "Muscle Master", "#", class: "navbar-brand"%>
+    <% if user_signed_in? %>
+      <%= link_to "Muscle Master", memos_path, class: "navbar-brand"%>
+    <% else %>
+      <%= link_to "Muscle Master", root_path, class: "navbar-brand"%>
+    <% end %>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse">
       <span class="navbar-toggler-icon"></span>
     </button>
 
     <div class="collapse navbar-collapse justify-content-end" id="navbarCollapse">
       <ul class="navbar-nav">
-        <li class="nav-item">
-          <%= link_to "SNS", tweets_path, class: "nav-link"%>
-        </li>
         <% if user_signed_in? %>
           <li class="nav-item">
-            <%#= link_to "Memo", user_memos_path(current_user.id), class: "nav-link"%>
-            <%= link_to "Memo", memos_path, class: "nav-link"%>
+            <%= link_to "トレシェア", tweets_path, class: "nav-link"%>
           </li>
           <li class="nav-item">
-            <%= link_to "Mypage", user_path(current_user.id), class: "nav-link"%>
+            <%= link_to "メモ", memos_path, class: "nav-link"%>
           </li>
           <li class="nav-item">
-            <%= link_to "Logout", destroy_user_session_path,method: :delete, class: "nav-link"%>
+            <%= link_to "マイページ", user_path(current_user.id), class: "nav-link"%>
+          </li>
+          <li class="nav-item">
+            <%= link_to "ログアウト", destroy_user_session_path,method: :delete, class: "nav-link"%>
           </li>
           <% else %>
           <li class="nav-item">
-            <%= link_to "Sign up", new_user_registration_path, class: "nav-link"%>
+            <%= link_to "サインアップ", new_user_registration_path, class: "nav-link"%>
           </li>
           <li class="nav-item">
-            <%= link_to "Login", new_user_session_path, class: "nav-link"%>
+            <%= link_to "ログイン", new_user_session_path, class: "nav-link"%>
           </li>
         <% end %>
       </ul>

--- a/app/views/users/_follow_count_text.html.erb
+++ b/app/views/users/_follow_count_text.html.erb
@@ -1,3 +1,3 @@
-<%= link_to following_user_path(@user), class: "no-text-decoration" do %>
+<%= link_to following_user_path(@user), class: "follow-count no-text-decoration" do %>
   <%= @user.following.length %>フォロー
 <% end %>

--- a/app/views/users/_follower_count_text.html.erb
+++ b/app/views/users/_follower_count_text.html.erb
@@ -1,3 +1,3 @@
-<%= link_to followers_user_path(@user), class: "no-text-decoration" do %>
+<%= link_to followers_user_path(@user), class: "follower-count no-text-decoration" do %>
   <%= @user.followers.length %>フォロワー
 <% end %> 

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -26,6 +26,7 @@
     <%= render "follow_form" %>
     <% if @user.id == current_user.id %>
       <%= link_to "情報を編集する", edit_user_registration_path, class: "user-edit-btn btn btn-outline-primary" %>
+      <%= link_to "退会する", user_registration_path, method: :delete, data: { confirm: "本当に退会しますか？" } , class: "user-edit-btn btn btn-outline-danger" %>
     <% end %>
   </div>
   


### PR DESCRIPTION
# what 
- ユーザー退会機能の実装
- フォロー機能のカウント表示を非同期に修正
-  ヘッダーのメニューを英語からカタカナに修正

# why
- ユーザーが退会できるようにするため
- フォロー時とフォロー解除時にカウント表示をスムーズにできるようにするため
- ヘッダーメニューを日本語表記として統一するため